### PR TITLE
BNL modified afmetrics_collector

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -4,3 +4,4 @@ Contributors
 
 * Fengping Hu <fengping@uchicago.edu>
 * Ilija Vukotic <ivukotic@uchicago.edu>
+* Tom Smith <tsmith@bnl.gov>

--- a/README.md
+++ b/README.md
@@ -155,11 +155,11 @@ Host total and available memory as reported by __psutil.virtual_memory()__. In b
 
 A typical full installation will collect ssh, batch (condor), jupyter, and host metrics and the command to run may look something like this:
 
-`afmetrics_collector -v -sjb --host -t "<token>"`
+`afmetrics_collector -v -sjb --host -t "<token>" -c "<cluster>"`
 
 The associated cron job to run this every 5 minutes (the default and recommended interval) may look like this:
 
-`*/5 * * * * root (KUBECONFIG=/etc/kubernetes/admin.conf /usr/local/bin/afmetrics_collector -v -sjb --host -t "<token>") >> /var/log/afmetrics/afmetrics.log 2>&1`
+`*/5 * * * * root (KUBECONFIG=/etc/kubernetes/admin.conf /usr/local/bin/afmetrics_collector -v -sjb --host -t "<token>" -c "<cluster>") >> /var/log/afmetrics/afmetrics.log 2>&1`
 
 ## Advanced Usage
 
@@ -167,7 +167,7 @@ The associated cron job to run this every 5 minutes (the default and recommended
 
 For debugging, you can opt to output everything to a local file instead of sending it to the logstash server with the `-d` flag:
 
-`afmetrics_collector -d -vv -sjb --host -t <token>`  
+`afmetrics_collector -d -vv -sjb --host -t <token> -c "<cluster>"`  
 This will output .json files in your current directory, and very verbose (`-vv`) logs in `/var/log/afmetrics/afmetrics.log`.  
 I would recommend to run this from within the `/var/log/afmetrics` directory so all the stuff to look at is in one place
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,36 @@
 AF Metrics Collector collects various metrics about user jobs from kubernetes,
 batch systems and send the collected metrics as json documents to an https endpoint.
 
+## Installation
+
+### Prerequisites:
+
+- Have installed `python3` and `pip3` system packages
+
+- Install some python dependencies for afmetrics_collector: `pip3 install -U setuptools setuptools_scm wheel importlib_metadata`
+
+- Create a directory for the log files: `mkdir /var/log/afmetrics`
+
+### Install afmetrics_collector:
+
+Clone the git repo onto your server
+
+Navigate to the project directory
+
+(optional) Make changes to setup.cfg
+
+Build with python3: `python3 setup.py bdist_wheel`
+
+Install with pip3: `pip3 install dist/afmetrics_collector-0.0*.whl`
+
+## Uninstallation
+
+`pip3 uninstall afmetrics-collector`
+
+## Sending documents
+
+All the documents should be __POST__ to <https://af.atlas-ml.org>.
+
 ## Documents
 
 Each document has to have a token field. To get a token for your AF, please contact Ilija Vukotic.
@@ -119,36 +149,6 @@ Host total and available memory as reported by __psutil.virtual_memory()__. In b
 }
 ```
 
-## Sending documents
-
-All the documents should be __POST__ to <https://af.atlas-ml.org>.
-
-## Installation
-
-### Prerequisites:
-
-- Have installed `python3` and `pip3` system packages
-
-- Install some python dependencies for afmetrics_collector: `pip3 install -U setuptools setuptools_scm wheel importlib_metadata`
-
-- Create a directory for the log files: `mkdir /var/log/afmetrics`
-
-### Install afmetrics_collector
-
-Clone the git repo onto your server
-
-Navigate to the project directory
-
-(optional) Make changes to setup.cfg
-
-Build with python3: `python3 setup.py bdist_wheel`
-
-Install with pip3: `pip3 install dist/afmetrics_collector-0.0*.whl`
-
-## Uninstallation
-
-`pip3 uninstall afmetrics-collector`
-
 ## Usage and examples
 
 **In the following replace all instances of `<token>` with your actual token, likewise for mentions of `<cluster>`, `<domain>`, `<salt>`, and so on. These are placeholders for your real values**
@@ -168,7 +168,7 @@ The associated cron job to run this every 5 minutes (the default and recommended
 For debugging, you can opt to output everything to a local file instead of sending it to the logstash server with the `-d` flag:
 
 `afmetrics_collector -d -vv -sjb --host -t <token>`  
-will output .json files in your current directory, and very verbose (`-vv`) logs in `/var/log/afmetrics/afmetrics.log`.  
+This will output .json files in your current directory, and very verbose (`-vv`) logs in `/var/log/afmetrics/afmetrics.log`.  
 I would recommend to run this from within the `/var/log/afmetrics` directory so all the stuff to look at is in one place
 
 ### Data Obfuscation and security
@@ -176,10 +176,12 @@ I would recommend to run this from within the `/var/log/afmetrics` directory so 
 For sites that wish to share usage metrics, but not info such as usernames and hostnames, data obfuscation flags `-o`, `-O`, and `-z` have been added:
 
 > `-o` : user name obfuscation
-> `-O` : host name obfuscation (followed by a string domanin name, ex.: -O 'bnl.gov')
-> `-z` : (optional) salt to make user obfuscation more secure, ex.: -o -z '5tKC%>f&%#hg'
+>
+> `-O` : host name obfuscation, followed by a string domanin name, ex.: `-O 'bnl.gov'`
+>
+> `-z` : (optional) salt to make user obfuscation more secure, ex.: `-o -z '5tKC%>f&%#hg'`
 
-Afmetrics_collector can be run as users other than root. If you wish to do this, make sure the ownership/permissions of the `/var/log/afmetrics` directory is such that the desired user can write to it
+Afmetrics_collector can be run as users other than **root**. If you wish to do this, make sure the ownership/permissions of the `/var/log/afmetrics` directory is such that the desired user can write to it
 
 A full example using all of the obfuscation and a local debug running as user 'nobody' might look something like this:
 
@@ -196,11 +198,11 @@ HOME=/var/log/afmetrics
 
 #### How it works: 
 
-Username obfuscation simply MD5 hashes username and truncates to the last 8 characters. Salt can be added to the username hash to strengthen against rainbow table attacks. If salt is used, make sure to use the same salt value across all your login nodes, otherwise the same user will be counted as a unique user.
+**Username obfuscation** simply MD5 hashes username and truncates to the last 8 characters. Salt can be added to the username hash to strengthen against rainbow table attacks. **If salt is used, make sure to use the same salt value across all your login nodes, otherwise the same user will be counted as a unique user if they log in on many nodes.**
 
-Hostname obfuscation is very basic so may need to be modified to suit your facility. It simply takes your hostname, strips off everything except the numbers, and prepends 'atlas' and appends your provided domain name string.  
-For example if your host is called `condor123.example.edu` and you call the hostname obfuscation flag with `-O bnl.gov` you will get `atlas123.bnl.gov` as your obfuscated domain name.  
-Provided the numbers from all your login hosts are different you should end up with no collisions. Modify in src/afmetrics_collector/skeleton.py to suit your needs
+**Hostname obfuscation** is very basic so may need to be modified to suit your facility. It simply takes your hostname, strips off everything except the numbers, and prepends **'atlas'** and appends **your provided domain name string**.  
+For example if your host is called `condor123.example.edu` and you call the hostname obfuscation flag with `-O "bnl.gov"` you will get `atlas123.bnl.gov` as your obfuscated domain name.  
+Provided the numbers from all your login hosts are different you should end up with no collisions. Modify in `src/afmetrics_collector/skeleton.py` to suit your needs
 
 Note
 ====

--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ For debugging, you can opt to output everything to a local file instead of sendi
 
 `afmetrics_collector -d -vv -sjb --host -t <token> -c "<cluster>"`  
 This will output .json files in your current directory, and very verbose (`-vv`) logs in `/var/log/afmetrics/afmetrics.log`.  
-I would recommend to run this from within the `/var/log/afmetrics` directory so all the stuff to look at is in one place
+I would recommend to run this from within the `/var/log/afmetrics` directory so all the stuff to look at is in one place.  
+A **token** is not necessary for debugging, so you can use `-d` before you have one
 
 ### Data Obfuscation and security
 
@@ -177,7 +178,7 @@ For sites that wish to share usage metrics, but not info such as usernames and h
 
 > `-o` : user name obfuscation
 >
-> `-O` : host name obfuscation, followed by a string domanin name, ex.: `-O 'bnl.gov'`
+> `-O` : host name obfuscation, followed by a string domain name, ex.: `-O 'bnl.gov'`
 >
 > `-z` : (optional) salt to make user obfuscation more secure, ex.: `-o -z '5tKC%>f&%#hg'`
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,85 @@ Host total and available memory as reported by __psutil.virtual_memory()__. In b
 
 All the documents should be __POST__ to <https://af.atlas-ml.org>.
 
+## Installation
+
+### Prerequisites:
+
+- Have installed `python3` and `pip3` system packages
+
+- Install some python dependencies for afmetrics_collector: `pip3 install -U setuptools setuptools_scm wheel importlib_metadata`
+
+- Create a directory for the log files: `mkdir /var/log/afmetrics`
+
+### Install afmetrics_collector
+
+Clone the git repo onto your server
+
+Navigate to the project directory
+
+(optional) Make changes to setup.cfg
+
+Build with python3: `python3 setup.py bdist_wheel`
+
+Install with pip3: `pip3 install dist/afmetrics_collector-0.0*.whl`
+
+## Uninstallation
+
+`pip3 uninstall afmetrics-collector`
+
+## Usage and examples
+
+**In the following replace all instances of `<token>` with your actual token, likewise for mentions of `<cluster>`, `<domain>`, `<salt>`, and so on. These are placeholders for your real values**
+
+A typical full installation will collect ssh, batch (condor), jupyter, and host metrics and the command to run may look something like this:
+
+`afmetrics_collector -v -sjb --host -t "<token>"`
+
+The associated cron job to run this every 5 minutes (the default and recommended interval) may look like this:
+
+`*/5 * * * * root (KUBECONFIG=/etc/kubernetes/admin.conf /usr/local/bin/afmetrics_collector -v -sjb --host -t "<token>") >> /var/log/afmetrics/afmetrics.log 2>&1`
+
+## Advanced Usage
+
+### Debugging
+
+For debugging, you can opt to output everything to a local file instead of sending it to the logstash server with the `-d` flag:
+
+`afmetrics_collector -d -vv -sjb --host -t <token>`  
+will output .json files in your current directory, and very verbose (`-vv`) logs in `/var/log/afmetrics/afmetrics.log`.  
+I would recommend to run this from within the `/var/log/afmetrics` directory so all the stuff to look at is in one place
+
+### Data Obfuscation and security
+
+For sites that wish to share usage metrics, but not info such as usernames and hostnames, data obfuscation flags `-o`, `-O`, and `-z` have been added:
+
+> `-o` : user name obfuscation
+> `-O` : host name obfuscation (followed by a string domanin name, ex.: -O 'bnl.gov')
+> `-z` : (optional) salt to make user obfuscation more secure, ex.: -o -z '5tKC%>f&%#hg'
+
+Afmetrics_collector can be run as users other than root. If you wish to do this, make sure the ownership/permissions of the `/var/log/afmetrics` directory is such that the desired user can write to it
+
+A full example using all of the obfuscation and a local debug running as user 'nobody' might look something like this:
+
+`su -s /bin/bash -c '(/usr/local/bin/afmetrics_collector -d -vv -sbj --host -t "<token>" -o -O "<domain>" -c "<cluster>" -z "<salt>") 2>&1' nobody`
+
+The associated cron `/etc/cron.d/afmetrics.cron` running all of the above in non-debug mode may looks like this:
+
+```
+### Afmetrics Collector ###
+SHELL=/bin/bash
+HOME=/var/log/afmetrics
+*/5 * * * * nobody (/usr/local/bin/afmetrics_collector -vv -sbj --host  -t "<token>" -o -O "<domain>" -c "<cluster>" -z "<salt>") >> /var/log/afmetrics/afmetrics.log 2>&1
+```
+
+#### How it works: 
+
+Username obfuscation simply MD5 hashes username and truncates to the last 8 characters. Salt can be added to the username hash to strengthen against rainbow table attacks. If salt is used, make sure to use the same salt value across all your login nodes, otherwise the same user will be counted as a unique user.
+
+Hostname obfuscation is very basic so may need to be modified to suit your facility. It simply takes your hostname, strips off everything except the numbers, and prepends 'atlas' and appends your provided domain name string.  
+For example if your host is called `condor123.example.edu` and you call the hostname obfuscation flag with `-O bnl.gov` you will get `atlas123.bnl.gov` as your obfuscated domain name.  
+Provided the numbers from all your login hosts are different you should end up with no collisions. Modify in src/afmetrics_collector/skeleton.py to suit your needs
+
 Note
 ====
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@
 
 [metadata]
 name = afmetrics_collector
-description = Add a short description here!
+description = BNL modified redacted afmetrics collector install
 author = Fengping Hu
 author_email = fengping@uchicago.edu
 license = MIT

--- a/src/afmetrics_collector/condor.py
+++ b/src/afmetrics_collector/condor.py
@@ -27,7 +27,7 @@ def get_condor_jobs():
 
     #'-completedsince', str(now - since_insecs) not working?
     try:
-        with subprocess.Popen(['condor_q',
+        with subprocess.Popen(['condor_q', '-all',
                                #'-completedsince', str(now - since_insecs),
                                '-constraint', constraint,
                                '-format',"%s ", 'Owner',

--- a/src/afmetrics_collector/skeleton.py
+++ b/src/afmetrics_collector/skeleton.py
@@ -163,7 +163,7 @@ def parse_args(args):
         "-O",
         "--obfuscate-hosts",
         dest="obf_hosts",
-        help="alter the hostnames before sending to logstash",
+        help="alter the hostnames before sending to logstash (usage -O \"<domain_name>\")",
         default="",
         type=str,
     )
@@ -174,6 +174,14 @@ def parse_args(args):
         dest="debug_local",
         help="output to a local json file in current directory",
         default=False,
+    )
+    parser.add_argument(
+        "-z",
+        "--salt",
+        dest="salt",
+        help="add salt to user name hash for added security (usage --salt \"<salt>\")",
+        default="",
+        type=str,
     )
     return parser.parse_args(args)
 
@@ -213,7 +221,7 @@ def main(args):
         if args.obf_users:
             # jupyter user hash
             for i, x in enumerate(users):
-                users[i] = hashlib.sha256(x.encode('utf-8')).hexdigest()[:8]
+                users[i] = hashlib.sha256((args.salt+x).encode('utf-8')).hexdigest()[:8]
             
         myobj = {'token': token,
                  'kind': 'jupyter-ml',
@@ -238,7 +246,7 @@ def main(args):
         if args.obf_users:
             # jupyter-coffea user hash
             for i, x in enumerate(users):
-                users[i] = hashlib.sha256(x.encode('utf-8')).hexdigest()[:8]
+                users[i] = hashlib.sha256((args.salt+x).encode('utf-8')).hexdigest()[:8]
 
         myobj = {'token': token,
                  'kind': 'jupyter-coffea',
@@ -263,7 +271,7 @@ def main(args):
         if args.obf_users:
             # ssh user hash
             for i, x in enumerate(users):
-                users[i] = hashlib.sha256(x.encode('utf-8')).hexdigest()[:8]
+                users[i] = hashlib.sha256((args.salt+x).encode('utf-8')).hexdigest()[:8]
         
         if args.obf_hosts != "":
             # atlas ssh host obfuscation
@@ -329,7 +337,7 @@ def main(args):
 
             if args.obf_users:
                 # condor user hash
-                myobj.update([('users',hashlib.sha256(myobj.get('users').encode('utf-8')).hexdigest()[:8])])
+                myobj.update([('users',hashlib.sha256((args.salt+myobj.get('users')).encode('utf-8')).hexdigest()[:8])])
 
             if args.debug_local:
                 # For local debugging
@@ -352,7 +360,7 @@ def main(args):
             myobj.update(job)
             if args.obf_users:
                 # condor user hash
-                myobj.update([('users',hashlib.sha256(myobj.get('users').encode('utf-8')).hexdigest()[:8])])
+                myobj.update([('users',hashlib.sha256((args.salt+myobj.get('users')).encode('utf-8')).hexdigest()[:8])])
             
             if args.debug_local:
                 # For local debugging

--- a/src/afmetrics_collector/skeleton.py
+++ b/src/afmetrics_collector/skeleton.py
@@ -21,11 +21,10 @@ import sys
 import socket
 import requests
 
-# Tom
-# only needed for testing
+# needed for debug
 import json
 
-# needed for obfuscation
+# needed for user obfuscation
 import hashlib
 
 from afmetrics_collector import __version__
@@ -58,7 +57,7 @@ def parse_args(args):
     Returns:
       :obj:`argparse.Namespace`: command line parameters namespace
     """
-    parser = argparse.ArgumentParser(description="Just a Fibonacci demonstration")
+    parser = argparse.ArgumentParser(description="Help for afmetrics_collector")
     parser.add_argument(
         "--version",
         action="version",
@@ -70,28 +69,32 @@ def parse_args(args):
         action="store_true",
         dest="host",
         help="collect ssh metrics",
-        default=False)
+        default=False
+    )
     parser.add_argument(
         "-s",
         "--ssh",
         action="store_true",
         dest="ssh",
         help="collect ssh metrics",
-        default=False)
+        default=False
+    )
     parser.add_argument(
         "-j",
         "--jupyter",
         action="store_true",
         dest="jupyter",
         help="collect jupyter metrics",
-        default=False)
+        default=False
+    )
     parser.add_argument(
         "-b",
         "--batch",
         action="store_true",
         dest="batch",
         help="collect batch(condor) metrics",
-        default=False)
+        default=False
+    )
     parser.add_argument(
         "-n",
         "--namespace",
@@ -106,7 +109,8 @@ def parse_args(args):
         dest="label",
         help="label of jupyter pods",
         default="owner",
-        type=str)
+        type=str
+    )
     parser.add_argument(
         "-t",
         "--token",
@@ -120,8 +124,7 @@ def parse_args(args):
         "--cluster",
         dest="cluster",
         help="the name of the af cluster",
-        #default="UC-AF",
-        default="BNL-SDCC",
+        default="UC-AF",
         type=str,
     )
     parser.add_argument(
@@ -129,9 +132,7 @@ def parse_args(args):
         "--url",
         dest="url",
         help="logstash url",
-        #default="https://af.atlas-ml.org/",
-        #For debugging
-        default="http://localhost/",
+        default="https://af.atlas-ml.org/",
         type=str,
     )
     parser.add_argument(
@@ -149,6 +150,30 @@ def parse_args(args):
         help="set loglevel to DEBUG",
         action="store_const",
         const=logging.DEBUG,
+    )
+    parser.add_argument(
+        "-o",
+        "--obfuscate-users",
+        action="store_true",
+        dest="obf_users",
+        help="hash the usernames before sending to logstash",
+        default=False,
+    )
+    parser.add_argument(
+        "-O",
+        "--obfuscate-hosts",
+        dest="obf_hosts",
+        help="alter the hostnames before sending to logstash",
+        default="",
+        type=str,
+    )
+    parser.add_argument(
+        "-d",
+        "--debug",
+        action="store_true",
+        dest="debug_local",
+        help="output to a local json file in current directory",
+        default=False,
     )
     return parser.parse_args(args)
 
@@ -185,80 +210,111 @@ def main(args):
         users=get_jupyter_users(args.ns, args.label)
         _logger.info("af jupyter-ml users: %s", users)
 
-        # jupyter user hash
-        for i, x in enumerate(users):
-            users[i] = hashlib.sha256(x.encode('utf-8')).hexdigest()[:8]
+        if args.obf_users:
+            # jupyter user hash
+            for i, x in enumerate(users):
+                users[i] = hashlib.sha256(x.encode('utf-8')).hexdigest()[:8]
             
         myobj = {'token': token,
                  'kind': 'jupyter-ml',
                  'cluster': cluster,
                  'jupyter_user_count': len(users),
                  'users': users}
-        _logger.debug("post to logstash: %s", myobj)
-        resp = requests.post(url, json=myobj)
-        _logger.debug("post status_code:%d",resp.status_code)
+        
+        if args.debug_local:
+            # For local debugging
+            json_object = json.dumps(myobj, indent=4)
+            with open("jupyter-debug.json", "a") as outfile:
+                outfile.write(json_object)
+        else: # post to logstash
+            _logger.debug("post to logstash: %s", myobj)
+            resp = requests.post(url, json=myobj)
+            _logger.debug("post status_code:%d",resp.status_code)
 
         _logger.info("collecting jupyter-coffea metrics")
         users=get_jupyter_users("coffea-casa", "jhub_user")
         _logger.info("af jupyter-coffea users: %s", users)
 
-        # jupyter-coffea user hash
-        for i, x in enumerate(users):
-            users[i] = hashlib.sha256(x.encode('utf-8')).hexdigest()[:8]
+        if args.obf_users:
+            # jupyter-coffea user hash
+            for i, x in enumerate(users):
+                users[i] = hashlib.sha256(x.encode('utf-8')).hexdigest()[:8]
 
         myobj = {'token': token,
                  'kind': 'jupyter-coffea',
                  'cluster': cluster,
                  'jupyter_user_count': len(users),
                  'users': users}
-        _logger.debug("post to logstash: %s", myobj)
-        resp = requests.post(url, json=myobj)
-        _logger.debug("post status_code:%d",resp.status_code)
+        if args.debug_local:
+            # For local debugging
+            json_object = json.dumps(myobj, indent=4)
+            with open("jupyter-debug.json", "a") as outfile:
+                outfile.write(json_object)
+        else: # post to logstash
+            _logger.debug("post to logstash: %s", myobj)
+            resp = requests.post(url, json=myobj)
+            _logger.debug("post status_code:%d",resp.status_code)
 
     if args.ssh:
         _logger.info("collecting ssh metrics")
         users=get_ssh_users()
         _logger.info("af ssh users: %s", users)
 
-        # ssh user hash
-        for i, x in enumerate(users):
-            users[i] = hashlib.sha256(x.encode('utf-8')).hexdigest()[:8]
-        # atlas BNL ssh host obfuscation
-        ssh_host_name = ''.join(['atlas',''.join([n for n in socket.gethostname() if n.isdigit()]),'.bnl.gov'])
+        if args.obf_users:
+            # ssh user hash
+            for i, x in enumerate(users):
+                users[i] = hashlib.sha256(x.encode('utf-8')).hexdigest()[:8]
+        
+        if args.obf_hosts != "":
+            # atlas ssh host obfuscation
+            ssh_host_name = ''.join(['atlas',''.join([n for n in socket.gethostname() if n.isdigit()]),".",args.obf_hosts])
+        else:
+            ssh_host_name = socket.gethostname()
 
         myobj = {'token': token,
                  'kind': 'ssh',
                  'cluster': cluster,
-                 #'login_node': socket.gethostname(),
                  'login_node': ssh_host_name,
                  'ssh_user_count': len(users),
                  'users': users}
-        #_logger.debug("post to logstash: %s", myobj)
-        #resp = requests.post(url, json=myobj)
-        #_logger.debug("post status_code:%d",resp.status_code)
+
+        if args.debug_local:
+            # For local debugging
+            json_object = json.dumps(myobj, indent=4)
+            with open("ssh.json", "a") as outfile:
+                outfile.write(json_object)
+        else: # post to logstash
+            _logger.debug("post to logstash: %s", myobj)
+            resp = requests.post(url, json=myobj)
+            _logger.debug("post status_code:%d",resp.status_code)
         
-        # For debugging purposes:
-        json_object = json.dumps(myobj, indent=4)
-        with open("test.json", "a") as outfile:
-            outfile.write(json_object)
 
     if args.host:
         _logger.info("collecting host metrics")
-        # atlas BNL host obfuscation
-        login_host_name = ''.join(['atlas',''.join([n for n in socket.gethostname() if n.isdigit()]),'.bnl.gov'])
+        if args.obf_hosts != "":
+            # atlas host obfuscation
+            login_host_name = ''.join(['atlas',''.join([n for n in socket.gethostname() if n.isdigit()]),".",args.obf_hosts])
+        else:
+            login_host_name = socket.gethostname()
+
         header = {'token': token,
                   'kind': 'host',
                   'cluster': cluster,
-                  #'login_node': socket.gethostname()}
                   'login_node': login_host_name }
 
         metrics = get_host_metrics(header=header)
         _logger.debug("af host metrics: %s", metrics)
 
         for metric in metrics:
-            _logger.debug("post to logstash: %s", metric)
-            resp = requests.post(url, json=metric)
-            _logger.debug("post status_code:%d",resp.status_code)
+            if args.debug_local:
+                # For local debugging
+                json_object = json.dumps(metric, indent=4)
+                with open("host.json", "a") as outfile:
+                    outfile.write(json_object)
+            else: # post to logstash
+                _logger.debug("post to logstash: %s", metric)
+                resp = requests.post(url, json=metric)
+                _logger.debug("post status_code:%d",resp.status_code)
 
     if args.batch:
         _logger.info("collecting batch metrics - current users")
@@ -270,13 +326,20 @@ def main(args):
                      'kind': 'condorjob',
                      'cluster': cluster}
             myobj.update(job)
-            myobj.update([('users',hashlib.sha256(myobj.get('users').encode('utf-8')).hexdigest()[:8])])
-            #_logger.debug("post to logstash: %s", myobj)
-            #resp = requests.post(url, json=myobj)
-            #_logger.debug("post status_code:%d",resp.status_code)
-            json_object = json.dumps(myobj, indent=4)
-            with open("test.json", "a") as outfile:
-                outfile.write(json_object)
+
+            if args.obf_users:
+                # condor user hash
+                myobj.update([('users',hashlib.sha256(myobj.get('users').encode('utf-8')).hexdigest()[:8])])
+
+            if args.debug_local:
+                # For local debugging
+                json_object = json.dumps(myobj, indent=4)
+                with open("condor.json", "a") as outfile:
+                    outfile.write(json_object)
+            else: # post to logstash
+                _logger.debug("post to logstash: %s", myobj)
+                resp = requests.post(url, json=myobj)
+                _logger.debug("post status_code:%d",resp.status_code)
 
         _logger.info("collecting batch metrics - job history")
         jobs=get_condor_history(since_insecs=360)
@@ -287,13 +350,19 @@ def main(args):
                      'cluster': cluster,
                      'state': 'finished'}
             myobj.update(job)
-            myobj.update([('users',hashlib.sha256(myobj.get('users').encode('utf-8')).hexdigest()[:8])])
-            #_logger.debug("post to logstash: %s", myobj)
-            #resp = requests.post(url, json=myobj)
-            #_logger.debug("post status_code:%d",resp.status_code)
-            json_object = json.dumps(myobj, indent=4)
-            with open("test.json", "a") as outfile:
-                outfile.write(json_object)
+            if args.obf_users:
+                # condor user hash
+                myobj.update([('users',hashlib.sha256(myobj.get('users').encode('utf-8')).hexdigest()[:8])])
+            
+            if args.debug_local:
+                # For local debugging
+                json_object = json.dumps(myobj, indent=4)
+                with open("condor.json", "a") as outfile:
+                    outfile.write(json_object)
+            else: # post to logstash
+                _logger.debug("post to logstash: %s", myobj)
+                resp = requests.post(url, json=myobj)
+                _logger.debug("post status_code:%d",resp.status_code)
 
 
 

--- a/src/afmetrics_collector/ssh.py
+++ b/src/afmetrics_collector/ssh.py
@@ -17,6 +17,9 @@ def get_ssh_users():
         with subprocess.Popen(['who'], stdout=subprocess.PIPE) as process:
             any(users.append(l.split()[0].decode("utf-8")) for l in process.stdout.readlines()
                     if l.split()[0].decode("utf-8") not in users)
+        with subprocess.Popen(['/usr/bin/last -s -5min | head -n -2'], shell=True, stdout=subprocess.PIPE) as process:
+            any(users.append(l.split()[0].decode("utf-8")) for l in process.stdout.readlines()
+                    if l.split()[0].decode("utf-8") not in users)
     except Exception as error:
         _logger.error(error)
 


### PR DESCRIPTION
Added some features with new options -d, -o, -O, -z. Defaults of these options is to do nothing, so without these options should function the same as before. See README.md for some details on changes, or email me (Tom - tsmith@bnl.gov), or comment on pull request for discussion. The goal is to add functionality while doing no harm. Cheers

- `-d` - debug for local output

- `-o` - user obfuscation

- `-O` - host obfuscation

- `-z` - user name hash salt value

- Fixed edge case potential for loss of ssh user metrics

- changed `condor_q` to `condor_q -all` to allow running as other users such as 'nobody'