### PR TITLE
Update ssh.py

### DIFF
--- a/src/afmetrics_collector/ssh.py
+++ b/src/afmetrics_collector/ssh.py
@@ -17,7 +17,7 @@ def get_ssh_users():
         with subprocess.Popen(['who'], stdout=subprocess.PIPE) as process:
             any(users.append(l.split()[0].decode("utf-8")) for l in process.stdout.readlines()
                     if l.split()[0].decode("utf-8") not in users)
-        with subprocess.Popen(['/usr/bin/last -s -5min | head -n -2'], shell=True, stdout=subprocess.PIPE) as process:
+        with subprocess.Popen(['/usr/bin/last -w -s -5min | head -n -2'], shell=True, stdout=subprocess.PIPE) as process:
             any(users.append(l.split()[0].decode("utf-8")) for l in process.stdout.readlines()
                     if l.split()[0].decode("utf-8") not in users)
     except Exception as error:


### PR DESCRIPTION
Fixed an edge case where username from 'who' does not match username from 'last' if longer than 8 char and may be counted as 2 separate users in the right conditions. adding '-w' flag to 'last' will use full names and will match correctly